### PR TITLE
Clear command after use

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -145,7 +145,8 @@
             var select = options.commands[activeCommandI].select;
 
             if (select) {
-                select.apply(target);
+              select.apply(target);
+              activeCommandI = undefined;
             }
           }
         });
@@ -407,6 +408,7 @@
 
               if( select ){
                 select.apply( ele );
+                activeCommandI = undefined;
               }
             }
 


### PR DESCRIPTION
I came across a slight bug: when I select a commend from cxtmenu it will apply on each node I select afterwards.
I found it very confusing, so I propose to change this behaviour - after calling `select` function we simply set active command to undefined. 

The same behaviour is when you open context menu, but will not select any command.

This change was tested on Firefox 37.0.2, Chromium 42.0.2311.135 and Opera 29.0.1795.47 (all of these on Linux).
